### PR TITLE
skip code blocks when running latex processing

### DIFF
--- a/src/obsidian/processors/latexProcessor.ts
+++ b/src/obsidian/processors/latexProcessor.ts
@@ -2,6 +2,23 @@ export class LatexProcessor {
     private singleLine = /\$(.*?)\$/g;
 
     process(markdown: string) {
+		return this.skipCodeBlocks(markdown);
+	}
+
+	skipCodeBlocks(markdown: string): string {
+		const regex = /(?<=(^|\r|\n|\r\n))`{3,}.*?(\r|\n|\r\n)[\s\S]*?(\r|\n|\r\n)`{3,}(\r|\n|\r\n)/;
+		const match = regex.exec(markdown);
+
+		if (match) {
+			return this.transformLatex(markdown.substring(0, match['index'])) +
+				match[0] +
+				this.skipCodeBlocks(markdown.substring(match['index'] + match[0].length));
+		} else {
+			return this.transformLatex(markdown);
+		}
+	}
+
+	private transformLatex(markdown: string) {
         const withoutEscapedCharaters = this.markEscapedCharacters(markdown);
         const processedMultiline = this.processMultiLine(
             withoutEscapedCharaters,

--- a/src/obsidian/processors/latexProcessor.ts
+++ b/src/obsidian/processors/latexProcessor.ts
@@ -6,8 +6,9 @@ export class LatexProcessor {
     }
 
     skipCodeBlocks(markdown: string): string {
+        console.log(`markdown: ${markdown}`);
         const regex =
-            /(?<=(^|\r|\n|\r\n))`{3,}.*?(\r|\n|\r\n)[\s\S]*?(\r|\n|\r\n)`{3,}(\r|\n|\r\n)/;
+            /(?<=(^|\r|\n|\r\n))`{3,}.*?(\r|\n|\r\n)[\s\S]*?(\r|\n|\r\n)`{3,}(?=($|\r|\n|\r\n))/;
         const match = regex.exec(markdown);
 
         if (match) {

--- a/src/obsidian/processors/latexProcessor.ts
+++ b/src/obsidian/processors/latexProcessor.ts
@@ -2,23 +2,28 @@ export class LatexProcessor {
     private singleLine = /\$(.*?)\$/g;
 
     process(markdown: string) {
-		return this.skipCodeBlocks(markdown);
-	}
+        return this.skipCodeBlocks(markdown);
+    }
 
-	skipCodeBlocks(markdown: string): string {
-		const regex = /(?<=(^|\r|\n|\r\n))`{3,}.*?(\r|\n|\r\n)[\s\S]*?(\r|\n|\r\n)`{3,}(\r|\n|\r\n)/;
-		const match = regex.exec(markdown);
+    skipCodeBlocks(markdown: string): string {
+        const regex =
+            /(?<=(^|\r|\n|\r\n))`{3,}.*?(\r|\n|\r\n)[\s\S]*?(\r|\n|\r\n)`{3,}(\r|\n|\r\n)/;
+        const match = regex.exec(markdown);
 
-		if (match) {
-			return this.transformLatex(markdown.substring(0, match['index'])) +
-				match[0] +
-				this.skipCodeBlocks(markdown.substring(match['index'] + match[0].length));
-		} else {
-			return this.transformLatex(markdown);
-		}
-	}
+        if (match) {
+            return (
+                this.transformLatex(markdown.substring(0, match['index'])) +
+                match[0] +
+                this.skipCodeBlocks(
+                    markdown.substring(match['index'] + match[0].length),
+                )
+            );
+        } else {
+            return this.transformLatex(markdown);
+        }
+    }
 
-	private transformLatex(markdown: string) {
+    private transformLatex(markdown: string) {
         const withoutEscapedCharaters = this.markEscapedCharacters(markdown);
         const processedMultiline = this.processMultiLine(
             withoutEscapedCharaters,

--- a/test/__snapshots__/codeBlocks.unit.test.ts.snap
+++ b/test/__snapshots__/codeBlocks.unit.test.ts.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Basic Markdown Syntax > Code Blocks 1`] = `
+"<!-- .slide: class="drop" -->
+<div class="" style="position: absolute; left: 0px; top: 0px; height: 700px; width: 960px; min-height: 700px; display: flex; flex-direction: column; align-items: center; justify-content: center" absolute="true">
+
+\`\`\`dockerfile
+FROM ubuntu
+\`\`\`
+</div>"
+`;
+
+exports[`Basic Markdown Syntax > Code Blocks with multiple $ characters 1`] = `
+"<!-- .slide: class="drop" -->
+<div class="" style="position: absolute; left: 0px; top: 0px; height: 700px; width: 960px; min-height: 700px; display: flex; flex-direction: column; align-items: center; justify-content: center" absolute="true">
+
+\`\`\`dockerfile
+USER $USER_NAME:$USER_NAME
+\`\`\`
+</div>"
+`;
+
+exports[`Basic Markdown Syntax > Math with Code Blocks 1`] = `
+"<!-- .slide: class="drop" -->
+<div class="" style="position: absolute; left: 0px; top: 0px; height: 700px; width: 960px; min-height: 700px; display: flex; flex-direction: column; align-items: center; justify-content: center" absolute="true">
+
+$egin{vmatrix}a & b\\
+c & d
+end{vmatrix}=ad-bc$
+
+\`\`\`dockerfile
+USER $USER_NAME:$USER_NAME
+\`\`\`
+
+You can also do inline math like \`$s^{-2}_{n}sum_{i=1}^{n}$\`
+</div>"
+`;
+
+exports[`Basic Markdown Syntax > Math with Multiple Code Blocks 1`] = `
+"<!-- .slide: class="drop" -->
+<div class="" style="position: absolute; left: 0px; top: 0px; height: 700px; width: 960px; min-height: 700px; display: flex; flex-direction: column; align-items: center; justify-content: center" absolute="true">
+
+$egin{vmatrix}a & b\\
+c & d
+end{vmatrix}=ad-bc$
+
+\`\`\`dockerfile
+USER $USER_NAME:$USER_NAME
+\`\`\`
+
+You can also do inline math like \`$s^{-2}_{n}sum_{i=1}^{n}$\`
+
+\`\`\`bash
+eval "$(/home/$USER_NAME/.rbenv/bin/rbenv init -)"
+\`\`\`
+
+That was ruby, now we have javascript:
+
+\`\`\`
+console.log("Hello world!")
+\`\`\`
+</div>"
+`;
+
+exports[`Code Block Syntax > Headers 1`] = `
+"<!-- .slide: class="drop" -->
+<div class="" style="position: absolute; left: 0px; top: 0px; height: 700px; width: 960px; min-height: 700px; display: flex; flex-direction: column; align-items: center; justify-content: center" absolute="true">
+
+\`\`\`
+USER $USER_NAME:$USER_NAME
+\`\`\`
+
+The above does not show backticks
+</div>"
+`;
+
+exports[`Code Block Syntax > Headers 2`] = `
+"<!-- .slide: class="drop" -->
+<div class="" style="position: absolute; left: 0px; top: 0px; height: 700px; width: 960px; min-height: 700px; display: flex; flex-direction: column; align-items: center; justify-content: center" absolute="true">
+
+\`\`\`
+USER \`$USER_NAME:$\`USER_NAME
+\`\`\`
+
+The above does show backticks
+</div>"
+`;
+
+exports[`Code Block Syntax > Headers 3`] = `
+"<!-- .slide: class="drop" -->
+<div class="" style="position: absolute; left: 0px; top: 0px; height: 700px; width: 960px; min-height: 700px; display: flex; flex-direction: column; align-items: center; justify-content: center" absolute="true">
+
+\`\`\`
+USER $USER_NAME:$USER_NAME
+\`\`\`
+
+The above does not show backticks
+</div>"
+`;

--- a/test/__snapshots__/codeBlocks.unit.test.ts.snap
+++ b/test/__snapshots__/codeBlocks.unit.test.ts.snap
@@ -97,3 +97,28 @@ USER $USER_NAME:$USER_NAME
 The above does not show backticks
 </div>"
 `;
+
+exports[`Embedded code has extra characters near dollar signs 1`] = `
+"<!-- .slide: class="drop" -->
+<div class="" style="position: absolute; left: 0px; top: 0px; height: 700px; width: 960px; min-height: 700px; display: flex; flex-direction: column; align-items: center; justify-content: center" absolute="true">
+
+\`\`\`javascript
+export class CounterService {
+  count$ = new BehaviorSubject(1000);
+
+  double$ = this.count$.pipe(map((count) => count * 2));
+  triple$ = this.count$.pipe(map((count) => count * 3));
+
+  combined$ = combineLatest([this.double$, this.triple$]).pipe(
+    map(([double, triple]) => double + triple)
+  );
+
+  over9000$ = this.combined$.pipe(map((combined) => combined > 9000));
+
+  message$ = this.over9000$.pipe(
+    map((over9000) => (over9000 ? "It's over 9000!" : "It's under 9000."))
+  );
+}
+\`\`\`
+</div>"
+`;

--- a/test/codeBlocks.unit.test.ts
+++ b/test/codeBlocks.unit.test.ts
@@ -74,7 +74,7 @@ The above does not show backticks
 test('Basic Markdown Syntax > Math with Code Blocks', () => {
 	const input = `$$\begin{vmatrix}a & b\\
 c & d
-end{vmatrix}=ad-bc$$
+\end{vmatrix}=ad-bc$$
 
 \`\`\`dockerfile
 USER $USER_NAME:$USER_NAME

--- a/test/codeBlocks.unit.test.ts
+++ b/test/codeBlocks.unit.test.ts
@@ -1,0 +1,118 @@
+import { MarkdownProcessor } from 'src/obsidian/markdownProcessor';
+import { obsidianUtils as utilsInstance } from './__mocks__/mockObsidianUtils';
+import { prepare } from './testUtils';
+
+test('Basic Markdown Syntax > Code Blocks', () => {
+	const input = `
+\`\`\`dockerfile
+FROM ubuntu
+\`\`\`
+`;
+
+	const { options, markdown } = prepare(input);
+	const sut = new MarkdownProcessor(utilsInstance);
+
+	return expect(sut.process(markdown, options)).toMatchSnapshot();
+});
+
+test('Basic Markdown Syntax > Code Blocks with multiple $ characters', () => {
+	const input = `
+\`\`\`dockerfile
+USER $USER_NAME:$USER_NAME
+\`\`\`
+`;
+
+	const { options, markdown } = prepare(input);
+	const sut = new MarkdownProcessor(utilsInstance);
+
+	return expect(sut.process(markdown, options)).toMatchSnapshot();
+});
+
+test('Code Block Syntax > Headers', () => {
+	const input = `
+\`\`\`
+USER $USER_NAME:$USER_NAME
+\`\`\`
+
+The above does not show backticks
+`;
+
+	const { options, markdown } = prepare(input);
+	const sut = new MarkdownProcessor(utilsInstance);
+
+	return expect(sut.process(markdown, options)).toMatchSnapshot();
+});
+
+test('Code Block Syntax > Headers', () => {
+	const input = ` \`\`\`
+USER $USER_NAME:$USER_NAME
+\`\`\`
+
+The above does show backticks
+`;
+
+	const { options, markdown } = prepare(input);
+	const sut = new MarkdownProcessor(utilsInstance);
+
+	return expect(sut.process(markdown, options)).toMatchSnapshot();
+});
+
+test('Code Block Syntax > Headers', () => {
+	const input = `\`\`\`
+USER $USER_NAME:$USER_NAME
+\`\`\`
+
+The above does not show backticks
+`;
+
+	const { options, markdown } = prepare(input);
+	const sut = new MarkdownProcessor(utilsInstance);
+
+	return expect(sut.process(markdown, options)).toMatchSnapshot();
+});
+
+test('Basic Markdown Syntax > Math with Code Blocks', () => {
+	const input = `$$\begin{vmatrix}a & b\\
+c & d
+end{vmatrix}=ad-bc$$
+
+\`\`\`dockerfile
+USER $USER_NAME:$USER_NAME
+\`\`\`
+
+You can also do inline math like $s^{-2}_{n}sum_{i=1}^{n}$`;
+
+	const { options, markdown } = prepare(input);
+	const sut = new MarkdownProcessor(utilsInstance);
+
+	return expect(sut.process(markdown, options)).toMatchSnapshot();
+});
+
+test('Basic Markdown Syntax > Math with Multiple Code Blocks', () => {
+	const input = `$$\begin{vmatrix}a & b\\
+c & d
+end{vmatrix}=ad-bc$$
+
+\`\`\`dockerfile
+USER $USER_NAME:$USER_NAME
+\`\`\`
+
+You can also do inline math like $s^{-2}_{n}sum_{i=1}^{n}$
+
+\`\`\`bash
+eval "$(/home/$USER_NAME/.rbenv/bin/rbenv init -)"
+\`\`\`
+
+That was ruby, now we have javascript:
+
+\`\`\`
+console.log("Hello world!")
+\`\`\`
+`;
+
+	const { options, markdown } = prepare(input);
+	const sut = new MarkdownProcessor(utilsInstance);
+
+	return expect(sut.process(markdown, options)).toMatchSnapshot();
+});
+

--- a/test/codeBlocks.unit.test.ts
+++ b/test/codeBlocks.unit.test.ts
@@ -116,3 +116,30 @@ console.log("Hello world!")
 	return expect(sut.process(markdown, options)).toMatchSnapshot();
 });
 
+test('Embedded code has extra characters near dollar signs', () => {
+	const input = `
+\`\`\`javascript
+export class CounterService {
+  count$ = new BehaviorSubject(1000);
+
+  double$ = this.count$.pipe(map((count) => count * 2));
+  triple$ = this.count$.pipe(map((count) => count * 3));
+
+  combined$ = combineLatest([this.double$, this.triple$]).pipe(
+    map(([double, triple]) => double + triple)
+  );
+
+  over9000$ = this.combined$.pipe(map((combined) => combined > 9000));
+
+  message$ = this.over9000$.pipe(
+    map((over9000) => (over9000 ? "It's over 9000!" : "It's under 9000."))
+  );
+}
+\`\`\``;
+
+	const { options, markdown } = prepare(input);
+	const sut = new MarkdownProcessor(utilsInstance);
+
+	return expect(sut.process(markdown, options)).toMatchSnapshot();
+});
+

--- a/test/codeBlocks.unit.test.ts
+++ b/test/codeBlocks.unit.test.ts
@@ -91,7 +91,7 @@ You can also do inline math like $s^{-2}_{n}sum_{i=1}^{n}$`;
 test('Basic Markdown Syntax > Math with Multiple Code Blocks', () => {
 	const input = `$$\begin{vmatrix}a & b\\
 c & d
-end{vmatrix}=ad-bc$$
+\end{vmatrix}=ad-bc$$
 
 \`\`\`dockerfile
 USER $USER_NAME:$USER_NAME


### PR DESCRIPTION
Fixes the issue reported in https://github.com/MSzturc/obsidian-advanced-slides/issues/244
