### PR TITLE
Update(reveal.html): Fix Mermaid theme logic

### DIFF
--- a/src/template/reveal.html
+++ b/src/template/reveal.html
@@ -217,7 +217,7 @@
                 smartypants: false,
             },
             mermaid: {
-                theme: isLight ? 'default' : 'dark',
+                theme: isLight(bgColor) ? 'default' : 'dark',
             },
             {{#enableCustomControls}}
             customcontrols: {


### PR DESCRIPTION
`isLight` is always truthy because it is a function.

Before:

![image](https://github.com/user-attachments/assets/74d8c2c6-5978-4567-9bc5-0fdc9ac1f170)

After:

![image](https://github.com/user-attachments/assets/13c5d54b-3781-4580-91a9-9d85336190a1)
