### PR TITLE
Adding Windows support for serving local files

### DIFF
--- a/src/reveal/revealServer.ts
+++ b/src/reveal/revealServer.ts
@@ -117,7 +117,10 @@ export class RevealServer {
                     if (sourceDir !== utils.vaultDirectory) {
                         const srcPath = path.join(sourceDir, file);
                         if (existsSync(srcPath)) {
-                            fetch = srcPath.replace(utils.vaultDirectory, "");
+                            fetch = path
+                                .relative(utils.vaultDirectory, srcPath)
+                                .split(path.sep)
+                                .join("/");
                         }
                     }
                     console.debug(


### PR DESCRIPTION
Serving local files is already supported on macOS. This change adds Windows support.  
In Windows 11 the Fastify catch all route (/*) returns a 404 when trying to serve local files.  
This PR changes the else block inside the revealServer.ts /* route to handle Windows file paths.  
Tested on macOS 26 and Windows 11. 
Code created with Google AI Studio