### PR TITLE
Fix custom CSS 404 on Windows due to path separator mismatch

### DIFF
--- a/src/reveal/revealRenderer.ts
+++ b/src/reveal/revealRenderer.ts
@@ -221,9 +221,17 @@ export class RevealRenderer {
     }
 
     private toExternalPath(urlPath: string): string {
-        return urlPath
-            .replace(this.utils.pluginDirectory, "")
-            .replace(this.utils.vaultDirectory, "");
+        // Normalize path separators to forward slashes before stripping base
+        // directories. On Windows, path.join() normalises all separators to '\',
+        // but vaultDirectory is constructed as `${getBasePath()}/` (trailing
+        // forward slash). The mismatch means the string-replace never matches on
+        // Windows and the full absolute path leaks into the <link> href → 404.
+        // Normalising both sides to '/' is a no-op on macOS/Linux (path.sep is
+        // already '/') so this does not change behaviour on non-Windows platforms.
+        const normalized = urlPath.split(path.sep).join("/");
+        return normalized
+            .replace(this.utils.pluginDirectory.split(path.sep).join("/"), "")
+            .replace(this.utils.vaultDirectory.split(path.sep).join("/"), "");
     }
 
     private async getPageTemplate(embed = false) {

--- a/src/reveal/revealRenderer.ts
+++ b/src/reveal/revealRenderer.ts
@@ -221,17 +221,12 @@ export class RevealRenderer {
     }
 
     private toExternalPath(urlPath: string): string {
-        // Normalize path separators to forward slashes before stripping base
-        // directories. On Windows, path.join() normalises all separators to '\',
-        // but vaultDirectory is constructed as `${getBasePath()}/` (trailing
-        // forward slash). The mismatch means the string-replace never matches on
-        // Windows and the full absolute path leaks into the <link> href → 404.
-        // Normalising both sides to '/' is a no-op on macOS/Linux (path.sep is
-        // already '/') so this does not change behaviour on non-Windows platforms.
-        const normalized = urlPath.split(path.sep).join("/");
-        return normalized
-            .replace(this.utils.pluginDirectory.split(path.sep).join("/"), "")
-            .replace(this.utils.vaultDirectory.split(path.sep).join("/"), "");
+        // On Windows, path.join() uses '\' but vaultDirectory has a trailing '/';
+        // normalize both sides so the replace always matches.
+        return urlPath
+            .replace(/\\/g, "/")
+            .replace(this.utils.pluginDirectory.replace(/\\/g, "/"), "")
+            .replace(this.utils.vaultDirectory.replace(/\\/g, "/"), "");
     }
 
     private async getPageTemplate(embed = false) {


### PR DESCRIPTION
## Problem

On Windows, any custom theme CSS stored in the vault's `assetsDirectory` always returns a 404 in the preview. Closes #301.

### Root cause

`toExternalPath()` strips the vault base directory from an absolute path using `String.replace()`. On Windows, `path.join()` normalises all separators to `\`, but `vaultDirectory` is constructed as `` `${getBasePath()}/` `` with a **trailing forward slash**. The mismatch means the replace never matches:

| Value | String |
|---|---|
| `vaultDirectory` | `C:\Users\me\Vault/` — trailing `/` from template literal |
| `urlPath` | `C:\Users\me\Vault\_Templates\css\theme.css` — all `\` from `path.join` |
| `replace` result | no match → full absolute path returned unchanged |

The full path is then written into the HTML as:
```html
<link rel="stylesheet" href="/C:\Users\me\Vault\_Templates\css\theme.css" />
```
The browser requests `GET /C:/Users/.../theme.css` → **404**.

Plugin-internal files (inside `pluginDirectory/css/`) are unaffected because both sides of that replace call use backslashes from `path.join`.

A secondary cascade error occurs because `--r-background-color` is undefined when the theme fails to load, causing `isLight()` to crash with `TypeError: object null is not iterable`.

## Fix

Normalise both the input path and the base directory strings to forward slashes before calling `replace`. `path.sep` is already `/` on macOS/Linux, so this is a **no-op on non-Windows platforms** and does not change existing behaviour.

```typescript
private toExternalPath(urlPath: string): string {
    const normalized = urlPath.split(path.sep).join("/");
    return normalized
        .replace(this.utils.pluginDirectory.split(path.sep).join("/"), "")
        .replace(this.utils.vaultDirectory.split(path.sep).join("/"), "");
}
```

## Testing

The existing test suite passes (2 pre-existing snapshot failures on Windows due to CRLF in test fixtures — unrelated to this change, present on `main` as well). The fix was manually verified on Windows 11 with a custom theme stored in `<vault>/_Templates/Reveal.js/css/`.
