### PR TITLE
Sync preview cursor for multi-file presentations when using embedded .md files

### DIFF
--- a/src/obsidian/obsidianUtils.ts
+++ b/src/obsidian/obsidianUtils.ts
@@ -286,6 +286,16 @@ export class ObsidianUtils implements MediaCollector {
         return file ? base + file.path : path;
     }
 
+    readFileRawByPath(filePath: string): string | null {
+        const absPath = this.absolute(filePath);
+        if (!absPath) return null;
+        try {
+            return readFileSync(absPath, { encoding: "utf-8" });
+        } catch {
+            return null;
+        }
+    }
+
     parseFile(filename: string, header: string) {
         const tfile = this.getTFile(filename);
 

--- a/src/reveal/revealPreviewView.ts
+++ b/src/reveal/revealPreviewView.ts
@@ -2,6 +2,7 @@ import {
     ItemView,
     MarkdownView,
     type Menu,
+    type TFile,
     type WorkspaceLeaf,
 } from "obsidian";
 import type { SlidesExtendedPlugin } from "src/slidesExtended-Plugin";
@@ -18,6 +19,16 @@ export class RevealPreviewView extends ItemView {
     private urlRegex = /#\/(\d*)(?:\/(\d*))?(?:\/(\d*))?/;
     private yaml: YamlParser;
     private plugin: SlidesExtendedPlugin;
+
+    private expandedCache: {
+        masterPath: string;
+        expandedMarkdown: string;
+        lineMap: Array<{ filename: string; localLine: number }>;
+        masterEmbedLines: Map<number, number>;
+        separators: Options;
+        masterYamlLineOffset: number;
+        chapterYamlOffsets: Map<string, number>;
+    } | null = null;
 
     constructor(
         leaf: WorkspaceLeaf,
@@ -52,6 +63,21 @@ export class RevealPreviewView extends ItemView {
         }
 
         window.addEventListener("message", this.onMessage.bind(this));
+
+        this.registerEvent(
+            this.app.vault.on("modify", () => {
+                this.expandedCache = null;
+            }),
+        );
+
+        this.registerEvent(
+            this.app.workspace.on("active-leaf-change", () => {
+                const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+                if (view) {
+                    this.onLineChanged(view.editor.getCursor().line);
+                }
+            }),
+        );
     }
 
     onPaneMenu(
@@ -120,7 +146,10 @@ export class RevealPreviewView extends ItemView {
         const iframe = viewContent.getElementsByTagName("iframe")[0];
 
         if (view && iframe) {
-            const [x, y] = this.getTargetSlide(line, view.data);
+            const masterFile = this.getMasterFile();
+            const [x, y] = masterFile
+                ? this.getTargetSlideMultiFile(line, view, masterFile)
+                : this.getTargetSlide(line, view.data);
             iframe.contentWindow.postMessage(
                 `{"method":"setState","args":[{"indexh":${x},"indexv":${y},"paused":false}]}`,
                 this.url,
@@ -168,6 +197,195 @@ export class RevealPreviewView extends ItemView {
 
         return slides.get([hX, vX].join(",")) + offset;
     }
+
+    // ── Multi-file sync ────────────────────────────────────────────────────────
+
+    private getMasterFile(): TFile | null {
+        try {
+            const url = new URL(this.url);
+            const filename = decodeURI(url.pathname.split("/").at(-1) ?? "");
+            if (!filename) return null;
+            return this.app.vault.getFiles().find((f) => f.name === filename) ?? null;
+        } catch {
+            return null;
+        }
+    }
+
+    private normalizeFilename(filename: string): string {
+        const name = filename.replace(/\\/g, "/").split("/").at(-1) ?? filename;
+        return name.endsWith(".md") ? name.slice(0, -3) : name;
+    }
+
+    private buildExpandedContent(
+        masterMarkdown: string,
+        masterBasename: string,
+    ): {
+        expandedMarkdown: string;
+        lineMap: Array<{ filename: string; localLine: number }>;
+        masterEmbedLines: Map<number, number>;
+        chapterYamlOffsets: Map<string, number>;
+    } {
+        const embedRegex = /^!\[\[(.+?)(?:\|[^\]]+)?\]\]$/;
+        const chapterYamlRegex = /^---\n[\s\S]*?\n---\n/;
+        const lines = masterMarkdown.split("\n");
+        const expandedLines: string[] = [];
+        const lineMap: Array<{ filename: string; localLine: number }> = [];
+        const masterEmbedLines = new Map<number, number>();
+        const chapterYamlOffsets = new Map<string, number>();
+
+        for (let i = 0; i < lines.length; i++) {
+            const match = embedRegex.exec(lines[i]);
+            if (match) {
+                const chapterName = match[1];
+                const content = this.plugin.obsidianUtils.parseFile(chapterName, null);
+                if (content != null) {
+                    // Compute YAML line offset for this chapter file
+                    const relativePath = this.plugin.obsidianUtils.getRelativePath(chapterName);
+                    if (relativePath) {
+                        const raw = this.plugin.obsidianUtils.readFileRawByPath(relativePath);
+                        if (raw) {
+                            const yamlMatch = chapterYamlRegex.exec(raw);
+                            if (yamlMatch) {
+                                const yamlLineCount = (yamlMatch[0].match(/\n/g) || []).length;
+                                chapterYamlOffsets.set(this.normalizeFilename(chapterName), yamlLineCount);
+                            }
+                        }
+                    }
+
+                    masterEmbedLines.set(i, expandedLines.length);
+                    const chapterLines = content.split("\n");
+                    for (let j = 0; j < chapterLines.length; j++) {
+                        expandedLines.push(chapterLines[j]);
+                        lineMap.push({ filename: chapterName, localLine: j });
+                    }
+                } else {
+                    // Chapter not found; treat the embed line as master content
+                    expandedLines.push(lines[i]);
+                    lineMap.push({ filename: masterBasename, localLine: i });
+                }
+            } else {
+                expandedLines.push(lines[i]);
+                lineMap.push({ filename: masterBasename, localLine: i });
+            }
+        }
+
+        return {
+            expandedMarkdown: expandedLines.join("\n"),
+            lineMap,
+            masterEmbedLines,
+            chapterYamlOffsets,
+        };
+    }
+
+    private getExpandedCache(masterFile: TFile): typeof this.expandedCache {
+        if (this.expandedCache?.masterPath === masterFile.path) {
+            return this.expandedCache;
+        }
+
+        const raw = this.plugin.obsidianUtils.readFileRawByPath(masterFile.path);
+        if (!raw) return null;
+
+        const { yamlOptions, markdown: masterMarkdown } =
+            this.yaml.parseYamlFrontMatter(raw);
+        const separators = this.yaml.getSlideOptions(yamlOptions);
+
+        const yamlLength = raw.indexOf(masterMarkdown);
+        const yamlLineCount = raw.substring(0, yamlLength).split(/^/gm).length;
+        const masterYamlLineOffset = yamlLineCount > 0 ? yamlLineCount - 1 : 0;
+
+        const masterBasename = this.normalizeFilename(masterFile.name);
+        const { expandedMarkdown, lineMap, masterEmbedLines, chapterYamlOffsets } =
+            this.buildExpandedContent(masterMarkdown, masterBasename);
+
+        this.expandedCache = {
+            masterPath: masterFile.path,
+            expandedMarkdown,
+            lineMap,
+            masterEmbedLines,
+            separators,
+            masterYamlLineOffset,
+            chapterYamlOffsets,
+        };
+        return this.expandedCache;
+    }
+
+    private findInLineMap(
+        targetBasename: string,
+        localLine: number,
+        lineMap: Array<{ filename: string; localLine: number }>,
+    ): number {
+        // Exact match
+        for (let i = 0; i < lineMap.length; i++) {
+            if (
+                this.normalizeFilename(lineMap[i].filename) === targetBasename &&
+                lineMap[i].localLine === localLine
+            ) {
+                return i;
+            }
+        }
+        // Fallback: last position at or before cursor for this file
+        let best = 0;
+        for (let i = 0; i < lineMap.length; i++) {
+            if (
+                this.normalizeFilename(lineMap[i].filename) === targetBasename &&
+                lineMap[i].localLine <= localLine
+            ) {
+                best = i;
+            }
+        }
+        return best;
+    }
+
+    private getTargetSlideMultiFile(
+        cursorLine: number,
+        view: MarkdownView,
+        masterFile: TFile,
+    ): [number, number] {
+        const cache = this.getExpandedCache(masterFile);
+        if (!cache) {
+            return this.getTargetSlide(cursorLine, view.data);
+        }
+
+        const { expandedMarkdown, lineMap, masterEmbedLines, separators, masterYamlLineOffset, chapterYamlOffsets } =
+            cache;
+        const masterBasename = this.normalizeFilename(masterFile.name);
+        const activeBasename = this.normalizeFilename(view.file.name);
+
+        let expandedCursorLine: number;
+
+        if (activeBasename === masterBasename) {
+            // Editing the master file: subtract YAML lines to get position within masterMarkdown
+            const localLine = cursorLine - masterYamlLineOffset;
+            if (masterEmbedLines.has(localLine)) {
+                // Cursor is on an ![[embed]] line — jump to start of that chapter
+                expandedCursorLine = masterEmbedLines.get(localLine)!;
+            } else {
+                expandedCursorLine = this.findInLineMap(masterBasename, localLine, lineMap);
+            }
+        } else {
+            // Editing a chapter file: subtract chapter YAML offset so localLine matches lineMap
+            const chapterYamlOffset = chapterYamlOffsets.get(activeBasename) ?? 0;
+            const localLine = cursorLine - chapterYamlOffset;
+            expandedCursorLine = this.findInLineMap(activeBasename, localLine, lineMap);
+        }
+
+        const slides = this.getSlideLines(expandedMarkdown, separators);
+        let resultKey: string | null = null;
+        for (const [key, value] of slides.entries()) {
+            if (value <= expandedCursorLine) {
+                resultKey = key;
+            } else {
+                break;
+            }
+        }
+        if (resultKey) {
+            const keys = resultKey.split(",");
+            return [Number.parseInt(keys[0], 10), Number.parseInt(keys[1], 10)];
+        }
+        return [0, 0];
+    }
+
+    // ── Slide line mapping ─────────────────────────────────────────────────────
 
     getSlideLines(source: string, separators: Options) {
         let store = new Map<number, string>();
@@ -266,6 +484,7 @@ export class RevealPreviewView extends ItemView {
     }
 
     onChange() {
+        this.expandedCache = null;
         this.reloadIframe();
     }
 

--- a/src/reveal/revealPreviewView.ts
+++ b/src/reveal/revealPreviewView.ts
@@ -71,11 +71,9 @@ export class RevealPreviewView extends ItemView {
         );
 
         this.registerEvent(
-            this.app.workspace.on("active-leaf-change", () => {
-                const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-                if (view) {
-                    this.onLineChanged(view.editor.getCursor().line);
-                }
+            this.app.workspace.on("active-leaf-change", (leaf: WorkspaceLeaf | null) => {
+                if (!(leaf?.view instanceof MarkdownView)) return;
+                this.onLineChanged((leaf.view as MarkdownView).editor.getCursor().line);
             }),
         );
     }
@@ -147,7 +145,9 @@ export class RevealPreviewView extends ItemView {
 
         if (view && iframe) {
             const masterFile = this.getMasterFile();
-            const [x, y] = masterFile
+            const isChapterFile = masterFile !== null &&
+                this.normalizeFilename(view.file.name) !== this.normalizeFilename(masterFile.name);
+            const [x, y] = isChapterFile
                 ? this.getTargetSlideMultiFile(line, view, masterFile)
                 : this.getTargetSlide(line, view.data);
             iframe.contentWindow.postMessage(


### PR DESCRIPTION
###  Problem

When a presentation uses multiple files (a master file that embeds chapters via ![[chapter]]), the preview panel only tracked cursor position within the currently open file. Switching to a different chapter file did nothing — the preview stayed wherever it was.

###   Solution

  src/obsidian/obsidianUtils.ts
  - Add readFileRawByPath() to read file content including YAML frontmatter (needed to compute line offsets).

  src/reveal/revealPreviewView.ts
  - On construction, register an active-leaf-change listener. When the user switches to a different markdown file, the preview syncs to the correct slide. The listener filters to MarkdownView leaves only — clicking the preview pane itself does not
  trigger a sync.
  - onLineChanged detects whether the currently active file is an embedded chapter of the presentation (i.e., its name differs from the master file in the URL). If so, it routes through new multi-file logic; otherwise the original single-file path is
  used unchanged.
  - Multi-file logic expands ![[...]] embeds from the master file into a flat line map, accounts for per-chapter YAML frontmatter offsets, and maps the editor cursor to the correct (indexh, indexv) slide coordinate in the expanded presentation.
  - The expansion result is memoized and invalidated on vault modify events.

  Single-file presentations are unaffected — they continue to use the original getTargetSlide path against live editor content.

*Disclaimer*: The code for this was largely written by claude.

###   Testing

  Create three files in a vault and open combined.md as a presentation:

* combined.md (master):
```
  ---
  ![[slides_a]]
  ---
  ![[slides_b]]
  ---
```
* slides_a.md:
```
  a
  --
  b
  --
  c
```
* slides_b.md:
``` 
  1
  --
  2
  --
  3
```

###  Expected behaviour
  - Open preview for combined.md
  - Open slides_a.md in the editor → preview jumps to the first chapter. Moving the cursor between slides a/b/c tracks vertically.
  - Switch to slides_b.md → preview jumps to the second chapter. Moving the cursor between slides 1/2/3 tracks vertically.
  - A single-file presentation with any separator convention continues to track exactly as before.

### Automated Test Suite
```
     Test Suites: 9 passed, 9 total
     Tests:       123 passed, 123 total
     Snapshots:   84 passed, 84 total
     Time:        4.509 s, estimated 8 s
     Ran all test suites.
```
