### PR TITLE
fix: guard isLight() against null match when --r-background-color is unresolvable

### DIFF
--- a/src/slidesExtended-Plugin.ts
+++ b/src/slidesExtended-Plugin.ts
@@ -203,7 +203,7 @@ export class SlidesExtendedPlugin extends Plugin {
 
     hideView() {
         if (this.settings.autoComplete === "inPreview") {
-            this.autoCompleteSuggester.deactivate();
+            this.autoCompleteSuggester?.deactivate();
         }
     }
 

--- a/src/template/embed.html
+++ b/src/template/embed.html
@@ -111,7 +111,9 @@
             optionEl.style.color = color;
             const normalizedColor = optionEl.style.color;
 
-            const [, c_r, c_g, c_b] = normalizedColor.match(/(\d+), (\d+), (\d+)/);
+            const match = normalizedColor.match(/(\d+), (\d+), (\d+)/);
+            if (!match) return false;
+            const [, c_r, c_g, c_b] = match;
 
             const brightness = ((c_r * 299) + (c_g * 587) + (c_b * 114)) / 1000;
             return brightness > 155;

--- a/src/template/reveal.html
+++ b/src/template/reveal.html
@@ -166,7 +166,9 @@
             optionEl.style.color = color;
             const normalizedColor = optionEl.style.color;
 
-            const [, c_r, c_g, c_b] = normalizedColor.match(/(\d+), (\d+), (\d+)/);
+            const match = normalizedColor.match(/(\d+), (\d+), (\d+)/);
+            if (!match) return false;
+            const [, c_r, c_g, c_b] = match;
 
             const brightness = ((c_r * 299) + (c_g * 587) + (c_b * 114)) / 1000;
             return brightness > 155;


### PR DESCRIPTION
## Summary

- `isLight()` normalizes a color by assigning it to an `<option>` element's style and reading it back. When `--r-background-color` is empty or a value the browser cannot resolve to `rgb(r, g, b)` in that context, `.match()` returns `null`.
- Destructuring `null` throws `TypeError: object null is not iterable`, aborting the script block before `const options` is assigned.
- This cascades into `ReferenceError: options is not defined` in the next `<script>` block, preventing `Reveal.initialize()` from running at all.

Fix: store the match result and guard with `if (!match) return false` (treating unresolvable colors as dark).

Affects both `src/template/reveal.html` and `src/template/embed.html`.

## Test plan

- [ ] Open a presentation with a theme whose `--r-background-color` resolves to a valid rgb value — light/dark detection should work as before
- [ ] Open a presentation where `--r-background-color` is empty or unresolvable — slideshow should initialize without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)