### PR TITLE
fix: normalize vaultDirectory before startsWith comparison on Windows

### DIFF
--- a/src/reveal/revealServer.ts
+++ b/src/reveal/revealServer.ts
@@ -111,7 +111,11 @@ export class RevealServer {
                         this._utils.vaultDirectory,
                         file.replace("embed/", ""),
                     );
-                    if (!embedFilePath.startsWith(this._utils.vaultDirectory)) {
+                    if (
+                        !embedFilePath.startsWith(
+                            path.normalize(this._utils.vaultDirectory),
+                        )
+                    ) {
                         reply.status(403).send();
                         return reply;
                     }
@@ -122,7 +126,11 @@ export class RevealServer {
                         this._utils.vaultDirectory,
                         file,
                     );
-                    if (!resolvedPath.startsWith(this._utils.vaultDirectory)) {
+                    if (
+                        !resolvedPath.startsWith(
+                            path.normalize(this._utils.vaultDirectory),
+                        )
+                    ) {
                         reply.status(403).send();
                         return reply;
                     }


### PR DESCRIPTION
The file location guards added in v2.3.6 use String.startsWith() to verify the resolved file path is within the vault directory. This breaks on Windows because the vault directory has a trailing forward slash (D:\vault/) while path.resolve() normalizes to backslashes (D:\vault\file.md).

Wrap vaultDirectory with path.normalize() before comparison, which strips trailing slashes and normalizes separators to platform-appropriate values. Has no effect on macOS/Linux.

Fixes #322 