### PR TITLE
Add 'Insert slide data-ids' command for syncing slides across tools

### DIFF
--- a/src/obsidian/slideIdGenerator.ts
+++ b/src/obsidian/slideIdGenerator.ts
@@ -1,0 +1,147 @@
+import { CommentParser } from "./comment";
+
+const commentParser = new CommentParser();
+
+function generateUUID(): string {
+    let uuid = "";
+    if (
+        typeof crypto !== "undefined" &&
+        typeof crypto.randomUUID === "function"
+    ) {
+        uuid = crypto.randomUUID();
+    } else {
+        uuid = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+            const r = (Math.random() * 16) | 0;
+            const v = c === "x" ? r : (r & 0x3) | 0x8;
+            return v.toString(16);
+        });
+    }
+    // Remove dashes to match slides.com and prevent regex parsing errors
+    return uuid.replaceAll("-", "");
+}
+
+export function assignSlideIds(
+    markdown: string,
+    separator: string,
+    verticalSeparator: string,
+): { modifiedMarkdown: string; hasChanges: boolean } {
+    const separatorRegex = new RegExp(separator, "gmi");
+    const verticalSeparatorRegex = new RegExp(verticalSeparator, "gmi");
+
+    interface Match {
+        start: number;
+        end: number;
+        content: string;
+    }
+    const matches: Match[] = [];
+
+    let match = separatorRegex.exec(markdown);
+    while (match !== null) {
+        matches.push({
+            start: match.index,
+            end: separatorRegex.lastIndex,
+            content: match[0],
+        });
+        if (match.index === separatorRegex.lastIndex) {
+            separatorRegex.lastIndex++;
+        }
+        match = separatorRegex.exec(markdown);
+    }
+
+    let vMatch = verticalSeparatorRegex.exec(markdown);
+    while (vMatch !== null) {
+        matches.push({
+            start: vMatch.index,
+            end: verticalSeparatorRegex.lastIndex,
+            content: vMatch[0],
+        });
+        if (vMatch.index === verticalSeparatorRegex.lastIndex) {
+            verticalSeparatorRegex.lastIndex++;
+        }
+        vMatch = verticalSeparatorRegex.exec(markdown);
+    }
+
+    // Sort matches chronologically
+    matches.sort((a, b) => a.start - b.start);
+
+    // Filter overlapping matches
+    const nonOverlapping: Match[] = [];
+    let lastEnd = 0;
+    for (const m of matches) {
+        if (m.start >= lastEnd) {
+            nonOverlapping.push(m);
+            lastEnd = m.end;
+        }
+    }
+
+    // Segment document into slides and separators
+    interface Segment {
+        type: "slide" | "separator";
+        content: string;
+    }
+    const segments: Segment[] = [];
+    let currentIdx = 0;
+    for (const m of nonOverlapping) {
+        if (m.start > currentIdx) {
+            segments.push({
+                type: "slide",
+                content: markdown.substring(currentIdx, m.start),
+            });
+        }
+        segments.push({ type: "separator", content: m.content });
+        currentIdx = m.end;
+    }
+    if (currentIdx < markdown.length) {
+        segments.push({
+            type: "slide",
+            content: markdown.substring(currentIdx),
+        });
+    }
+
+    // Process slide content segments
+    const slideCommentRegex = /<!--\s*(?:\.)?slide.*-->/;
+    let hasChanges = false;
+
+    for (const segment of segments) {
+        if (segment.type === "slide") {
+            const content = segment.content;
+            if (slideCommentRegex.test(content)) {
+                const commentMatch = slideCommentRegex.exec(content)?.[0];
+                if (commentMatch) {
+                    const comment = commentParser.parseLine(commentMatch);
+                    if (comment && !comment.hasAttribute("data-id")) {
+                        comment.addAttribute("data-id", generateUUID());
+                        segment.content = content.replace(
+                            slideCommentRegex,
+                            commentParser.commentToString(comment),
+                        );
+                        hasChanges = true;
+                    }
+                }
+            } else {
+                // Insert a slide comment at the first non-empty line
+                const lines = content.split("\n");
+                let insertIdx = 0;
+                while (
+                    insertIdx < lines.length &&
+                    lines[insertIdx].trim() === ""
+                ) {
+                    insertIdx++;
+                }
+                const uuid = generateUUID();
+                lines.splice(
+                    insertIdx,
+                    0,
+                    `<!-- .slide: data-id="${uuid}" -->`,
+                );
+                segment.content = lines.join("\n");
+                hasChanges = true;
+            }
+        }
+    }
+
+    return {
+        modifiedMarkdown: segments.map((s) => s.content).join(""),
+        hasChanges,
+    };
+}

--- a/src/slidesExtended-Plugin.ts
+++ b/src/slidesExtended-Plugin.ts
@@ -1,7 +1,8 @@
-import { addIcon, Plugin, type TAbstractFile } from "obsidian";
+import { addIcon, Notice, Plugin, type TAbstractFile } from "obsidian";
 import type { SlidesExtendedSettings } from "./@types";
 import { EmbeddedSlideProcessor } from "./obsidian/embeddedSlideProcessor";
 import { ObsidianUtils } from "./obsidian/obsidianUtils";
+import { assignSlideIds } from "./obsidian/slideIdGenerator";
 import { AutoCompleteSuggest } from "./obsidian/suggesters/AutoCompleteSuggester";
 import { LineSelectionListener } from "./obsidian/suggesters/lineSelectionListener";
 import {
@@ -16,6 +17,7 @@ import {
 } from "./slidesExtended-constants";
 import { SlidesExtendedDistribution } from "./slidesExtended-Distribution";
 import { SlidesExtendedSettingTab } from "./slidesExtended-SettingTab";
+import { YamlParser } from "./yaml/yamlParser";
 
 export class SlidesExtendedPlugin extends Plugin {
     settings: SlidesExtendedSettings;
@@ -96,6 +98,40 @@ export class SlidesExtendedPlugin extends Plugin {
                     return;
                 }
                 instance.exportAsHtml();
+            },
+        });
+        this.addCommand({
+            id: "insert-slide-ids",
+            name: "Insert slide data-ids",
+            editorCallback: async (editor) => {
+                const markdown = editor.getValue();
+
+                // Get separators defined in frontmatter or fall back to defaults
+                const yamlParser = new YamlParser(this.settings);
+                const { yamlOptions } =
+                    yamlParser.parseYamlFrontMatter(markdown);
+                const options = yamlParser.getSlideOptions(yamlOptions);
+
+                const separator = options.separator || "\\r?\\n---\\r?\\n";
+                const verticalSeparator =
+                    options.verticalSeparator || "\\r?\\n--\\r?\\n";
+
+                const { modifiedMarkdown, hasChanges } = assignSlideIds(
+                    markdown,
+                    separator,
+                    verticalSeparator,
+                );
+
+                if (hasChanges) {
+                    const cursor = editor.getCursor();
+                    const scrollInfo = editor.getScrollInfo();
+                    editor.setValue(modifiedMarkdown);
+                    editor.setCursor(cursor);
+                    editor.scrollTo(scrollInfo.left, scrollInfo.top);
+                    new Notice("Slide data-ids inserted successfully.");
+                } else {
+                    new Notice("All slides already have data-ids.");
+                }
             },
         });
         this.addCommand({

--- a/test/slideIds.unit.test.ts
+++ b/test/slideIds.unit.test.ts
@@ -1,0 +1,124 @@
+import { assignSlideIds } from "../src/obsidian/slideIdGenerator";
+import { YamlStore } from "../src/yaml/yamlStore";
+import { getSlideOptions } from "./testUtils";
+
+describe("Slide ID Generator", () => {
+    const separator = "\\r?\\n---\\r?\\n";
+    const verticalSeparator = "\\r?\\n--\\r?\\n";
+
+    beforeEach(() => {
+        YamlStore.getInstance().options = getSlideOptions({});
+    });
+
+    test("Plain Slide Deck: adds data-id to all slides", () => {
+        const input = `Slide 1 content
+
+---
+
+Slide 2 content
+
+--
+
+Slide 3 content`;
+
+        const { modifiedMarkdown, hasChanges } = assignSlideIds(
+            input,
+            separator,
+            verticalSeparator
+        );
+
+        expect(hasChanges).toBe(true);
+
+        // Split slides
+        const parts = modifiedMarkdown.split(/\r?\n(?:---|--)\r?\n/);
+        expect(parts).toHaveLength(3);
+
+        // Each part should contain a slide comment with a data-id attribute
+        for (const part of parts) {
+            expect(part).toMatch(/<!-- \.slide: .*data-id="[a-f0-9]{32}".* -->/);
+            // Verify there are no dashes in the UUID
+            const match = part.match(/data-id="([^"]+)"/);
+            expect(match).not.toBeNull();
+            const id = match![1];
+            expect(id).toHaveLength(32);
+            expect(id).not.toContain("-");
+        }
+    });
+
+    test("Slides with Existing Slide Comments: appends data-id and preserves transformed attributes", () => {
+        const input = `<!-- .slide: bg="black" class="my-class" -->
+# Slide 1
+
+---
+
+<!-- slide bg="red" -->
+# Slide 2`;
+
+        const { modifiedMarkdown, hasChanges } = assignSlideIds(
+            input,
+            separator,
+            verticalSeparator
+        );
+
+        expect(hasChanges).toBe(true);
+
+        // Slide 1 should preserve transformed bg (data-background-color="black") and classes, plus data-id
+        expect(modifiedMarkdown).toContain('data-background-color="black"');
+        expect(modifiedMarkdown).toContain('class="my-class');
+        expect(modifiedMarkdown).toContain('data-id="');
+
+        // Slide 2 should be updated with transformed bg and data-id
+        expect(modifiedMarkdown).toContain('data-background-color="red"');
+
+        // Let's verify each has a 32-char dashless hex data-id
+        const matches = [...modifiedMarkdown.matchAll(/data-id="([a-f0-9]{32})"/g)];
+        expect(matches).toHaveLength(2);
+        for (const match of matches) {
+            expect(match[1]).not.toContain("-");
+        }
+    });
+
+    test("Slides with Existing data-id: remains completely untouched", () => {
+        const input = `<!-- .slide: data-id="alreadyexists123" bg="blue" -->
+# Slide 1
+
+---
+
+<!-- .slide: data-id="alreadyexists456" -->
+# Slide 2`;
+
+        const { modifiedMarkdown, hasChanges } = assignSlideIds(
+            input,
+            separator,
+            verticalSeparator
+        );
+
+        expect(hasChanges).toBe(false);
+        expect(modifiedMarkdown).toBe(input);
+    });
+
+    test("Preserved Separators: keeps custom formatting and spaces around separators completely identical", () => {
+        const input = `Slide 1
+
+   ---   
+
+Slide 2
+
+\t--\t
+
+Slide 3`;
+
+        const customSeparator = "\\s*---\\s*";
+        const customVerticalSeparator = "\\s*--\\s*";
+
+        const { modifiedMarkdown, hasChanges } = assignSlideIds(
+            input,
+            customSeparator,
+            customVerticalSeparator
+        );
+
+        expect(hasChanges).toBe(true);
+        expect(modifiedMarkdown).toContain("   ---   ");
+        expect(modifiedMarkdown).toContain("\t--\t");
+    });
+});


### PR DESCRIPTION
Add 'Insert slide data-ids' command for syncing slides across tools and Auto-Animate

Introduced a command palette editor action "Insert slide data-ids" that adds dashless UUID `data-id` attributes to the active reveal.js slides. This allows external tools to uniquely identify individual slides and enables stable reveal.js Auto-Animate transitions. Operating via the editor callback ensures the modification is fully undoable (Cmd+Z) and preserves the user's cursor position and scroll coordinates.

- Uses a segment-based precision parser to preserve custom slide separators and whitespace.
- Generates dashless UUIDs to align with slides.com standards and prevent regex parsing errors.
- Integrates with the built-in CommentParser to preserve existing slide properties.