### PR TITLE
format processor fix

### DIFF
--- a/src/obsidian/processors/formatProcessor.ts
+++ b/src/obsidian/processors/formatProcessor.ts
@@ -8,18 +8,14 @@ export class FormatProcessor implements Processor {
     private highlightedRegex = /==([\s\S]*?)==/g;
     private commentRegex = /%%([\s\S]*?)%%/g;
 
-    process(markdown: string, options?: Options) {
+    process(markdown: string, options: Options) {
         let output = markdown;
-        if (options) {
-            processBySlide(markdown, options, (slide) => {
-                let newSlide = slide;
-                newSlide = skipMathCodeBlocks(slide, (md) =>
-                    this.formatText(md),
-                );
-                output = output.replace(slide, () => newSlide);
-                return newSlide;
-            });
-        }
+        processBySlide(markdown, options, (slide) => {
+            let newSlide = slide;
+            newSlide = skipMathCodeBlocks(slide, (md) => this.formatText(md));
+            output = output.replace(slide, () => newSlide);
+            return newSlide;
+        });
         return output;
     }
 

--- a/src/obsidian/processors/formatProcessor.ts
+++ b/src/obsidian/processors/formatProcessor.ts
@@ -1,24 +1,31 @@
+// Process formatting
+// See docs/content/basic-syntax/textStyle.md
+
 import type { Options, Processor } from "../../@types";
 import { processBySlide, skipMathCodeBlocks } from "../obsidianUtils";
 
 export class FormatProcessor implements Processor {
-    private markRegex = /==([^=]*)==/gm;
-    private commentRegex = /%%([^%]*)%%/gm;
+    private highlightedRegex = /==([\s\S]*?)==/g;
+    private commentRegex = /%%([\s\S]*?)%%/g;
 
-    process(markdown: string, options: Options) {
+    process(markdown: string, options?: Options) {
         let output = markdown;
-        processBySlide(markdown, options, (slide) => {
-            let newSlide = slide;
-            newSlide = skipMathCodeBlocks(slide, (md) => this.formatText(md));
-            output = output.replace(slide, () => newSlide);
-            return newSlide;
-        });
+        if (options) {
+            processBySlide(markdown, options, (slide) => {
+                let newSlide = slide;
+                newSlide = skipMathCodeBlocks(slide, (md) =>
+                    this.formatText(md),
+                );
+                output = output.replace(slide, () => newSlide);
+                return newSlide;
+            });
+        }
         return output;
     }
 
     private formatText(markdown: string): string {
         return markdown
-            .replaceAll(this.markRegex, "<mark>$1</mark>")
+            .replaceAll(this.highlightedRegex, "<mark>$1</mark>")
             .replaceAll(this.commentRegex, "");
     }
 }


### PR DESCRIPTION
1. Fixed the regexes.

`/==([^=]*)==/gm` => `/==([\s\S]*?)==/g`
` /%%([^%]*)%%/gm` => `/%%([\s\S]*?)%%/g`

You do not need to exclude `%` and `=` from the available characters because when they stand alone they do not conflict with `%%` and `==`. Therefore, you should instead use a non-greedy catch of all whitespace and all non-whitespace characters (i.e. truly any character) instead.
The `m` flag is not needed because we do not use `^` or `$`.

The new regexes will correctly handle these:

```
==
10/2 = 50%
==

%%
10/2 = 50%
%%
```

2. Made `options` optional in `process` to make TS happy.

3. Optional: Renamed `markRegex` to `highlightedRegex` because we are searching for highlighted text in MD not `<mark>` in HTML.