### PR TITLE
Fix bug report template label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,7 +1,8 @@
 name: Bug Report
 description: File a bug report
 title: "🐛 "
-labels: ["type: bug"]
+labels:
+  - bug
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

- Update the bug report issue template to use the existing `bug` label.
- The template currently references `type: bug`, which does not exist in this repo.

## Testing

- `git diff --check`
- `pnpm fix`
- `pnpm exec jest --watchman=false`

`pnpm build` completed the Biome check and production esbuild step, then failed in the postbuild `pnpm run test` step because Watchman tried to write `~/Library/LaunchAgents/com.github.facebook.watchman.plist` in the sandbox. Tests passed separately with Watchman disabled.
