### PR TITLE
Keep slide separators inert inside fenced code

### DIFF
--- a/src/obsidian/fencedCode.ts
+++ b/src/obsidian/fencedCode.ts
@@ -1,0 +1,145 @@
+import type { Options } from "../@types";
+
+export type FenceRange = {
+    end: number;
+    start: number;
+};
+
+function escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function getFenceRanges(markdown: string): FenceRange[] {
+    const ranges: FenceRange[] = [];
+    const lineRegex = /[^\r\n]*(?:\r\n|\r|\n|$)/g;
+    let activeFence:
+        | {
+              character: string;
+              length: number;
+              start: number;
+          }
+        | undefined;
+
+    for (const lineMatch of markdown.matchAll(lineRegex)) {
+        if (lineMatch[0] === "") {
+            break;
+        }
+
+        const line = lineMatch[0].replace(/(?:\r\n|\r|\n)$/, "");
+
+        if (activeFence) {
+            const closingFence = new RegExp(
+                `^ {0,3}${escapeRegex(activeFence.character)}{${
+                    activeFence.length
+                },}[\\t ]*$`,
+            );
+
+            if (closingFence.test(line)) {
+                ranges.push({
+                    start: activeFence.start,
+                    // The closing fence belongs to the protected range, but its
+                    // line ending may lead the following slide separator.
+                    end: lineMatch.index + line.length,
+                });
+                activeFence = undefined;
+            }
+            continue;
+        }
+
+        const openingFence = /^(?: {0,3})(`{3,}|~{3,})(.*)$/.exec(line);
+        if (!openingFence) {
+            continue;
+        }
+
+        const marker = openingFence[1];
+        const infoString = openingFence[2];
+        if (marker.startsWith("`") && infoString.includes("`")) {
+            continue;
+        }
+
+        activeFence = {
+            character: marker[0],
+            length: marker.length,
+            start: lineMatch.index,
+        };
+    }
+
+    if (activeFence) {
+        ranges.push({ start: activeFence.start, end: markdown.length });
+    }
+
+    return ranges;
+}
+
+export function overlapsFence(
+    match: RegExpExecArray,
+    fenceRanges: FenceRange[],
+): boolean {
+    const matchEnd = match.index + match[0].length;
+    return fenceRanges.some(
+        ({ start, end }) => match.index < end && matchEnd > start,
+    );
+}
+
+/**
+ * Temporarily replace separator text inside fences while Slides Extended runs
+ * processors that split the raw note into slides. Line endings remain intact
+ * so the fenced block retains its original Markdown structure.
+ */
+export function protectFencedSeparators(
+    markdown: string,
+    options: Pick<Options, "separator" | "verticalSeparator">,
+): {
+    markdown: string;
+    restore: (processed: string) => string;
+} {
+    const separatorRegex = new RegExp(
+        `${options.separator}${
+            options.verticalSeparator ? `|${options.verticalSeparator}` : ""
+        }`,
+        "gm",
+    );
+    const fenceRanges = getFenceRanges(markdown);
+    const replacements = new Map<string, string>();
+    let nextToken = 0;
+    let lastIndex = 0;
+    let protectedMarkdown = "";
+
+    const createToken = () => {
+        let token: string;
+        do {
+            token = `\uE000slides-extended-separator-${nextToken++}\uE001`;
+        } while (markdown.includes(token));
+        return token;
+    };
+
+    for (const match of markdown.matchAll(separatorRegex)) {
+        if (!overlapsFence(match, fenceRanges)) {
+            continue;
+        }
+
+        protectedMarkdown += markdown.substring(lastIndex, match.index);
+        protectedMarkdown += match[0].replace(/[^\r\n]+/g, (segment) => {
+            const token = createToken();
+            replacements.set(token, segment);
+            return token;
+        });
+        lastIndex = match.index + match[0].length;
+    }
+
+    if (replacements.size === 0) {
+        return { markdown, restore: (processed) => processed };
+    }
+
+    protectedMarkdown += markdown.substring(lastIndex);
+    return {
+        markdown: protectedMarkdown,
+        restore: (processed) => {
+            let restored = processed;
+            for (const [token, separator] of replacements) {
+                restored = restored.replaceAll(token, separator);
+            }
+            return restored;
+        },
+    };
+}

--- a/src/obsidian/markdownProcessor.ts
+++ b/src/obsidian/markdownProcessor.ts
@@ -1,5 +1,6 @@
 import type { Options, Processor } from "../@types";
 import { YamlStore } from "../yaml/yamlStore";
+import { protectFencedSeparators } from "./fencedCode";
 import type { ObsidianUtils } from "./obsidianUtils";
 import { AutoClosingProcessor } from "./processors/autoClosingProcessor";
 import { BlockProcessor } from "./processors/blockProcessor";
@@ -87,7 +88,11 @@ export class MarkdownProcessor {
     process(markdown: string, options: Options) {
         YamlStore.getInstance().options = options;
 
-        let processedMarkdown = this.trimEnding(markdown, options);
+        const protectedSeparators = protectFencedSeparators(markdown, options);
+        let processedMarkdown = this.trimEnding(
+            protectedSeparators.markdown,
+            options,
+        );
         if (options.log) {
             this.log("begin", markdown, processedMarkdown);
         }
@@ -103,6 +108,8 @@ export class MarkdownProcessor {
 
         // Third phase: Content processors
         processedMarkdown = this.processContent(processedMarkdown, options);
+
+        processedMarkdown = protectedSeparators.restore(processedMarkdown);
 
         if (options.log) {
             this.log("end", markdown, processedMarkdown);

--- a/src/reveal/fenceAwareSlidify.ts
+++ b/src/reveal/fenceAwareSlidify.ts
@@ -1,91 +1,11 @@
 import type { Options } from "../@types";
-
-type FenceRange = {
-    end: number;
-    start: number;
-};
+import { getFenceRanges, overlapsFence } from "../obsidian/fencedCode";
 
 type SlideGroup = string | string[];
 
 type Slidify = (markdown: string, options: Partial<Options>) => string;
 
 export const INERT_SEPARATOR = "(?!)";
-
-function escapeRegex(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function getFenceRanges(markdown: string): FenceRange[] {
-    const ranges: FenceRange[] = [];
-    const lineRegex = /[^\r\n]*(?:\r\n|\r|\n|$)/g;
-    let activeFence:
-        | {
-              character: string;
-              length: number;
-              start: number;
-          }
-        | undefined;
-    for (const lineMatch of markdown.matchAll(lineRegex)) {
-        if (lineMatch[0] === "") {
-            break;
-        }
-
-        const line = lineMatch[0].replace(/(?:\r\n|\r|\n)$/, "");
-
-        if (activeFence) {
-            const closingFence = new RegExp(
-                `^ {0,3}${escapeRegex(activeFence.character)}{${
-                    activeFence.length
-                },}[\\t ]*$`,
-            );
-
-            if (closingFence.test(line)) {
-                ranges.push({
-                    start: activeFence.start,
-                    // The closing fence belongs to the protected range, but its
-                    // line ending may be the leading newline of the following
-                    // slide separator.
-                    end: lineMatch.index + line.length,
-                });
-                activeFence = undefined;
-            }
-            continue;
-        }
-
-        const openingFence = /^(?: {0,3})(`{3,}|~{3,})(.*)$/.exec(line);
-        if (!openingFence) {
-            continue;
-        }
-
-        const marker = openingFence[1];
-        const infoString = openingFence[2];
-        if (marker.startsWith("`") && infoString.includes("`")) {
-            continue;
-        }
-
-        activeFence = {
-            character: marker[0],
-            length: marker.length,
-            start: lineMatch.index,
-        };
-    }
-
-    if (activeFence) {
-        ranges.push({ start: activeFence.start, end: markdown.length });
-    }
-
-    return ranges;
-}
-
-function overlapsFence(
-    match: RegExpExecArray,
-    fenceRanges: FenceRange[],
-): boolean {
-    const matchEnd = match.index + match[0].length;
-    return fenceRanges.some(
-        ({ start, end }) => match.index < end && matchEnd > start,
-    );
-}
 
 function getSeparatorMatches(
     markdown: string,

--- a/src/reveal/fenceAwareSlidify.ts
+++ b/src/reveal/fenceAwareSlidify.ts
@@ -1,0 +1,187 @@
+import type { Options } from "../@types";
+
+type FenceRange = {
+    end: number;
+    start: number;
+};
+
+type SlideGroup = string | string[];
+
+type Slidify = (markdown: string, options: Partial<Options>) => string;
+
+export const INERT_SEPARATOR = "(?!)";
+
+function escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getFenceRanges(markdown: string): FenceRange[] {
+    const ranges: FenceRange[] = [];
+    const lineRegex = /[^\r\n]*(?:\r\n|\r|\n|$)/g;
+    let activeFence:
+        | {
+              character: string;
+              length: number;
+              start: number;
+          }
+        | undefined;
+    for (const lineMatch of markdown.matchAll(lineRegex)) {
+        if (lineMatch[0] === "") {
+            break;
+        }
+
+        const line = lineMatch[0].replace(/(?:\r\n|\r|\n)$/, "");
+
+        if (activeFence) {
+            const closingFence = new RegExp(
+                `^ {0,3}${escapeRegex(activeFence.character)}{${
+                    activeFence.length
+                },}[\\t ]*$`,
+            );
+
+            if (closingFence.test(line)) {
+                ranges.push({
+                    start: activeFence.start,
+                    // The closing fence belongs to the protected range, but its
+                    // line ending may be the leading newline of the following
+                    // slide separator.
+                    end: lineMatch.index + line.length,
+                });
+                activeFence = undefined;
+            }
+            continue;
+        }
+
+        const openingFence = /^(?: {0,3})(`{3,}|~{3,})(.*)$/.exec(line);
+        if (!openingFence) {
+            continue;
+        }
+
+        const marker = openingFence[1];
+        const infoString = openingFence[2];
+        if (marker.startsWith("`") && infoString.includes("`")) {
+            continue;
+        }
+
+        activeFence = {
+            character: marker[0],
+            length: marker.length,
+            start: lineMatch.index,
+        };
+    }
+
+    if (activeFence) {
+        ranges.push({ start: activeFence.start, end: markdown.length });
+    }
+
+    return ranges;
+}
+
+function overlapsFence(
+    match: RegExpExecArray,
+    fenceRanges: FenceRange[],
+): boolean {
+    const matchEnd = match.index + match[0].length;
+    return fenceRanges.some(
+        ({ start, end }) => match.index < end && matchEnd > start,
+    );
+}
+
+function getSeparatorMatches(
+    markdown: string,
+    options: Pick<Options, "separator" | "verticalSeparator">,
+): RegExpExecArray[] {
+    const separatorRegex = new RegExp(
+        `${options.separator}${
+            options.verticalSeparator ? `|${options.verticalSeparator}` : ""
+        }`,
+        "gm",
+    );
+    const fenceRanges = getFenceRanges(markdown);
+    const matches: RegExpExecArray[] = [];
+    for (const match of markdown.matchAll(separatorRegex)) {
+        if (!overlapsFence(match, fenceRanges)) {
+            matches.push(match);
+        }
+    }
+
+    return matches;
+}
+
+/**
+ * Split Markdown using reveal.js semantics while ignoring separators inside
+ * fenced code blocks. Individual slides are still rendered by reveal.js so
+ * notes and script-end escaping retain their upstream behavior.
+ */
+export function fenceAwareSlidify(
+    markdown: string,
+    options: Pick<
+        Options,
+        "notesSeparator" | "separator" | "verticalSeparator"
+    >,
+    slidify: Slidify,
+): string {
+    const horizontalSeparatorRegex = new RegExp(options.separator);
+    const sectionStack: SlideGroup[] = [];
+    let lastIndex = 0;
+    let wasHorizontal = true;
+
+    for (const match of getSeparatorMatches(markdown, options)) {
+        const isHorizontal = horizontalSeparatorRegex.test(match[0]);
+
+        if (!isHorizontal && wasHorizontal) {
+            sectionStack.push([]);
+        }
+
+        const content = markdown.substring(lastIndex, match.index);
+        if (isHorizontal && wasHorizontal) {
+            sectionStack.push(content);
+        } else {
+            (sectionStack[sectionStack.length - 1] as string[]).push(content);
+        }
+
+        lastIndex = match.index + match[0].length;
+        wasHorizontal = isHorizontal;
+    }
+
+    const remaining = markdown.substring(lastIndex);
+    if (wasHorizontal) {
+        sectionStack.push(remaining);
+    } else {
+        (sectionStack[sectionStack.length - 1] as string[]).push(remaining);
+    }
+
+    const renderSlide = (content: string) =>
+        slidify(content, {
+            notesSeparator: options.notesSeparator,
+            separator: INERT_SEPARATOR,
+            verticalSeparator: INERT_SEPARATOR,
+        });
+
+    return sectionStack
+        .map((group) => {
+            if (Array.isArray(group)) {
+                return `<section >${group.map(renderSlide).join("")}</section>`;
+            }
+            return renderSlide(group);
+        })
+        .join("");
+}
+
+/**
+ * reveal.js processes every data-markdown section again in the browser. At
+ * that point Slides Extended has already split the presentation, so all slide
+ * and notes separators must be disabled to keep verbatim content inert.
+ */
+export function preventBrowserResplitting(slides: string): string {
+    const attributes = [
+        `data-separator="${INERT_SEPARATOR}"`,
+        `data-separator-vertical="${INERT_SEPARATOR}"`,
+        `data-separator-notes="${INERT_SEPARATOR}"`,
+    ].join(" ");
+
+    return slides.replace(
+        /<section\s+data-markdown>/g,
+        `<section ${attributes} data-markdown>`,
+    );
+}

--- a/src/reveal/revealRenderer.ts
+++ b/src/reveal/revealRenderer.ts
@@ -11,6 +11,10 @@ import {
 import { DEFAULTS } from "../slidesExtended-constants";
 import { has, isEmpty } from "../util";
 import { YamlParser } from "../yaml/yamlParser";
+import {
+    fenceAwareSlidify,
+    preventBrowserResplitting,
+} from "./fenceAwareSlidify";
 import { md } from "./markdown";
 import { RevealExporter } from "./revealExporter";
 
@@ -98,18 +102,12 @@ export class RevealRenderer {
 
         const prefetched = await this.utils.fetchRemoteMarkdown(markdown);
         const processedMarkdown = this.processor.process(prefetched, options);
-        const rawSlides = this.slidify(processedMarkdown, slidifyOptions);
-        // Stamp separator attributes on every <section data-markdown> element so that
-        // browser-side reveal.js re-processes each pre-split slide with the same
-        // separators, preventing the default '\r?\n---\r?\n' from splitting slide
-        // content that contains '---' as a horizontal rule or thematic break.
-        const separatorAttrs = this.buildSeparatorAttributes(slidifyOptions);
-        const slides = separatorAttrs
-            ? rawSlides.replace(
-                  /<section data-markdown>/g,
-                  `<section ${separatorAttrs} data-markdown>`,
-              )
-            : rawSlides;
+        const rawSlides = fenceAwareSlidify(
+            processedMarkdown,
+            slidifyOptions,
+            (content, options) => this.slidify(content, options),
+        );
+        const slides = preventBrowserResplitting(rawSlides);
 
         const cssPaths = this.getAssetPaths(
             options.css,
@@ -249,27 +247,10 @@ export class RevealRenderer {
         return "";
     }
 
-    private buildSeparatorAttributes(slidifyOptions: Partial<Options>): string {
-        const attrs: string[] = [];
-        if (slidifyOptions.separator) {
-            attrs.push(
-                `data-separator="${slidifyOptions.separator.replace(/"/g, "&quot;")}"`,
-            );
-        }
-        if (slidifyOptions.verticalSeparator) {
-            attrs.push(
-                `data-separator-vertical="${slidifyOptions.verticalSeparator.replace(/"/g, "&quot;")}"`,
-            );
-        }
-        if (slidifyOptions.notesSeparator) {
-            attrs.push(
-                `data-separator-notes="${slidifyOptions.notesSeparator.replace(/"/g, "&quot;")}"`,
-            );
-        }
-        return attrs.join(" ");
-    }
-
-    private slidify(markdown: string, slidifyOptions: unknown): string {
+    private slidify(
+        markdown: string,
+        slidifyOptions: Partial<Options>,
+    ): string {
         return md.slidify(markdown, slidifyOptions);
     }
 

--- a/src/yaml/yamlParser.ts
+++ b/src/yaml/yamlParser.ts
@@ -38,13 +38,18 @@ export class YamlParser {
         };
     }
 
-    getSlidifyOptions(options: Partial<Options>) {
+    getSlidifyOptions(
+        options: Partial<Options>,
+    ): Pick<Options, "notesSeparator" | "separator" | "verticalSeparator"> {
         const slidifyProps = [
             "separator",
             "verticalSeparator",
             "notesSeparator",
         ];
-        return pick(options, slidifyProps);
+        return pick(options, slidifyProps) as Pick<
+            Options,
+            "notesSeparator" | "separator" | "verticalSeparator"
+        >;
     }
 
     getRevealOptions(options: Partial<Options>) {

--- a/test/fencedSeparator.unit.test.ts
+++ b/test/fencedSeparator.unit.test.ts
@@ -1,8 +1,11 @@
+import { MarkdownProcessor } from "../src/obsidian/markdownProcessor";
 import {
     fenceAwareSlidify,
     INERT_SEPARATOR,
     preventBrowserResplitting,
 } from "../src/reveal/fenceAwareSlidify";
+import { obsidianUtils as utilsInstance } from "./__mocks__/mockObsidianUtils";
+import { prepare } from "./testUtils";
 
 const notesSeparator = "note:";
 
@@ -31,7 +34,100 @@ function countMatches(value: string, pattern: RegExp): number {
     return value.match(pattern)?.length ?? 0;
 }
 
+function processPresentation(input: string): string {
+    const { options, markdown } = prepare(input);
+    const processor = new MarkdownProcessor(utilsInstance);
+    const processed = processor.process(markdown, options);
+
+    return preventBrowserResplitting(
+        fenceAwareSlidify(processed, options, (content, _slideOptions) => {
+            const safeContent = content.replace(
+                /<\/script>/g,
+                "__SCRIPT_END__",
+            );
+            return `<section  data-markdown><script type="text/template">${safeContent}</script></section>`;
+        }),
+    );
+}
+
 describe("fenced slide separators", () => {
+    test("protects the default separator through the complete processor pipeline", () => {
+        const input = `---
+title: "minimal example"
+verticalSeparator: "\\r?\\n###\\r?\\n"
+---
+
+# First vertical slide
+
+###
+
+# Second vertical slide
+
+\`\`\`yaml
+---
+fenced: Verbatim
+---
+\`\`\``;
+        const result = processPresentation(input);
+
+        expect(countMatches(result, /data-markdown/g)).toBe(2);
+        expect(result).toContain("```yaml\n---\nfenced: Verbatim\n---\n```");
+    });
+
+    test("still splits the default separator outside fences through the complete pipeline", () => {
+        const input = `# First horizontal slide
+
+---
+
+# Second horizontal slide
+
+\`\`\`yaml
+---
+fenced: Verbatim
+---
+\`\`\``;
+        const result = processPresentation(input);
+
+        expect(countMatches(result, /data-markdown/g)).toBe(2);
+        expect(result).toContain("```yaml\n---\nfenced: Verbatim\n---\n```");
+    });
+
+    test("protects custom horizontal and vertical separators in both fence styles", () => {
+        const input = `---
+separator: "\\r?\\n@@@\\r?\\n"
+verticalSeparator: "\\r?\\n###\\r?\\n"
+---
+
+# First horizontal slide
+
+@@@
+
+# Second horizontal slide
+
+###
+
+# Vertical slide
+
+\`\`\`text
+@@@
+verbatim horizontal separator
+\`\`\`
+
+~~~text
+###
+verbatim vertical separator
+~~~`;
+        const result = processPresentation(input);
+
+        expect(countMatches(result, /data-markdown/g)).toBe(3);
+        expect(result).toContain(
+            "```text\n@@@\nverbatim horizontal separator\n```",
+        );
+        expect(result).toContain(
+            "~~~text\n###\nverbatim vertical separator\n~~~",
+        );
+    });
+
     test("keeps default horizontal separators inert inside a backtick fence", () => {
         const input = `# First vertical slide
 

--- a/test/fencedSeparator.unit.test.ts
+++ b/test/fencedSeparator.unit.test.ts
@@ -1,0 +1,156 @@
+import {
+    fenceAwareSlidify,
+    INERT_SEPARATOR,
+    preventBrowserResplitting,
+} from "../src/reveal/fenceAwareSlidify";
+
+const notesSeparator = "note:";
+
+function slidify(
+    markdown: string,
+    separator = "\r?\n---\r?\n",
+    verticalSeparator = "\r?\n###\r?\n",
+) {
+    const rawSlides = fenceAwareSlidify(
+        markdown,
+        { notesSeparator, separator, verticalSeparator },
+        (content, options) => {
+            expect(options.separator).toBe(INERT_SEPARATOR);
+            expect(options.verticalSeparator).toBe(INERT_SEPARATOR);
+            const safeContent = content.replace(
+                /<\/script>/g,
+                "__SCRIPT_END__",
+            );
+            return `<section  data-markdown><script type="text/template">${safeContent}</script></section>`;
+        },
+    );
+    return preventBrowserResplitting(rawSlides);
+}
+
+function countMatches(value: string, pattern: RegExp): number {
+    return value.match(pattern)?.length ?? 0;
+}
+
+describe("fenced slide separators", () => {
+    test("keeps default horizontal separators inert inside a backtick fence", () => {
+        const input = `# First vertical slide
+
+###
+
+# Second vertical slide
+
+\`\`\`yaml
+---
+fenced: Verbatim
+---
+\`\`\``;
+
+        const result = slidify(input);
+
+        expect(countMatches(result, /data-markdown/g)).toBe(2);
+        expect(result).toContain("```yaml\n---\nfenced: Verbatim\n---\n```");
+        expect(result).toContain(
+            `<section data-separator="${INERT_SEPARATOR}" data-separator-vertical="${INERT_SEPARATOR}" data-separator-notes="${INERT_SEPARATOR}" data-markdown>`,
+        );
+    });
+
+    test("still splits horizontal separators outside the fence", () => {
+        const input = `# First horizontal slide
+
+---
+
+# Second horizontal slide
+
+\`\`\`yaml
+---
+fenced: Verbatim
+---
+\`\`\``;
+
+        const result = slidify(input);
+
+        expect(countMatches(result, /data-markdown/g)).toBe(2);
+        expect(countMatches(result, /data-separator="\(\?!\)"/g)).toBe(2);
+        expect(result).toContain("```yaml\n---\nfenced: Verbatim\n---\n```");
+    });
+
+    test("keeps configured horizontal separators inert inside a fence", () => {
+        const input = `# First horizontal slide
+
+@@@
+
+# Second horizontal slide
+
+\`\`\`text
+@@@
+verbatim separator
+@@@
+\`\`\``;
+
+        const result = slidify(input, "\r?\n@@@\r?\n");
+
+        expect(countMatches(result, /data-markdown/g)).toBe(2);
+        expect(result).toContain("```text\n@@@\nverbatim separator\n@@@\n```");
+    });
+
+    test("supports tilde fences, longer fences, and CRLF", () => {
+        const input = [
+            "# First slide",
+            "---",
+            "# Second slide",
+            "~~~~yaml",
+            "---",
+            "fenced: Verbatim",
+            "---",
+            "~~~~",
+            "---",
+            "# Third slide",
+        ].join("\r\n");
+
+        const result = slidify(input);
+
+        expect(countMatches(result, /data-markdown/g)).toBe(3);
+        expect(result).toContain(
+            "~~~~yaml\r\n---\r\nfenced: Verbatim\r\n---\r\n~~~~",
+        );
+    });
+
+    test("treats an unclosed fence as extending to the end of the note", () => {
+        const input = `# Only slide
+
+\`\`\`yaml
+---
+fenced: Verbatim`;
+
+        const result = slidify(input);
+
+        expect(countMatches(result, /data-markdown/g)).toBe(1);
+        expect(result).toContain("```yaml\n---\nfenced: Verbatim");
+    });
+
+    test("preserves reveal.js horizontal precedence for overlapping patterns", () => {
+        const input = `# First slide
+
+###
+
+# Second slide`;
+
+        const result = slidify(input, "\r?\n###\r?\n", "\r?\n###\r?\n");
+
+        expect(countMatches(result, /data-markdown/g)).toBe(2);
+        expect(countMatches(result, /<section >/g)).toBe(0);
+    });
+
+    test("retains reveal.js script-end protection inside fenced examples", () => {
+        const input = `# Slide
+
+\`\`\`html
+</script>
+\`\`\``;
+
+        const result = slidify(input);
+
+        expect(result).toContain("__SCRIPT_END__");
+        expect(result).not.toContain("```html\n</script>");
+    });
+});


### PR DESCRIPTION
Fixes #399.

Summary

* Ignore configured horizontal and vertical slide separators when they occur inside fenced code blocks.
* Protect fenced separator text throughout the Slides Extended preprocessing pipeline, then restore the original verbatim content.
* Split slides outside fences with reveal.js-compatible horizontal precedence.
* Disable reveal.js re-splitting after Slides Extended has produced the section structure.

This keeps the default --- separator and custom separators inert inside backtick or tilde fences while preserving normal horizontal and vertical slide boundaries outside them.

Validation

* Added end-to-end regression coverage for the issue’s default-separator example.
* Verified that ordinary default separators still split slides.
* Covered custom horizontal and vertical separators in both backtick and tilde fences.
* Covered CRLF, longer and unclosed fences, overlapping patterns, and </script> escaping.
* pnpm fix
* pnpm test: 132 tests passed
* pnpm build
* Manually tested in Obsidian preview and browser export with Slides Extended 2.4.2: default and custom horizontal/vertical separators render correctly with no console errors.