### PR TITLE
Keep media references inert inside fenced code

### DIFF
--- a/src/obsidian/obsidianUtils.ts
+++ b/src/obsidian/obsidianUtils.ts
@@ -64,20 +64,46 @@ export function skipCodeBlocks(
     markdown: string,
     processRemainingText: (markdown: string) => string,
 ): string {
-    const codeBlockRegex =
-        /^(\s*)(`{3,})(.*?)[\r\n][\s\S]*?(?:\r|\n|\r\n)\1\2(?=$|[\r\n])/gm;
-    const match = codeBlockRegex.exec(markdown);
-    if (match) {
-        return (
-            processRemainingText(markdown.substring(0, match.index)) +
-            match[0] +
-            skipCodeBlocks(
-                markdown.substring(match.index + match[0].length),
-                processRemainingText,
-            )
+    const openingFence = /^ {0,3}(`{3,}|~{3,})(.*)(?:\r\n|\r|\n|$)/gm;
+    let result = "";
+    let lastIndex = 0;
+
+    while (true) {
+        const openingMatch = openingFence.exec(markdown);
+        if (!openingMatch) {
+            break;
+        }
+
+        const marker = openingMatch[1];
+        const infoString = openingMatch[2];
+        if (marker.startsWith("`") && infoString.includes("`")) {
+            continue;
+        }
+
+        result += processRemainingText(
+            markdown.substring(lastIndex, openingMatch.index),
         );
+
+        const closingFence = new RegExp(
+            `^ {0,3}${marker[0]}{${marker.length},}[\\t ]*(?:\\r\\n|\\r|\\n|$)`,
+            "gm",
+        );
+        closingFence.lastIndex = openingFence.lastIndex;
+        const closingMatch = closingFence.exec(markdown);
+        const fenceEnd = closingMatch
+            ? closingMatch.index + closingMatch[0].length
+            : markdown.length;
+
+        result += markdown.substring(openingMatch.index, fenceEnd);
+        lastIndex = fenceEnd;
+        openingFence.lastIndex = fenceEnd;
+
+        if (!closingMatch) {
+            return result;
+        }
     }
-    return processRemainingText(markdown);
+
+    return result + processRemainingText(markdown.substring(lastIndex));
 }
 
 export class ObsidianUtils implements MediaCollector {

--- a/src/obsidian/processors/mediaProcessor.ts
+++ b/src/obsidian/processors/mediaProcessor.ts
@@ -8,7 +8,7 @@ import {
     mimeTypeFor,
 } from "../../util";
 import { CommentParser } from "../comment";
-import type { ObsidianUtils } from "../obsidianUtils";
+import { type ObsidianUtils, skipCodeBlocks } from "../obsidianUtils";
 
 export class MediaProcessor implements Processor {
     private utils: ObsidianUtils;
@@ -26,6 +26,12 @@ export class MediaProcessor implements Processor {
     }
 
     process(markdown: string) {
+        return skipCodeBlocks(markdown, (remainingText) =>
+            this.processRemainingText(remainingText),
+        );
+    }
+
+    private processRemainingText(markdown: string) {
         return markdown
             .split("\n")
             .map((line) => {

--- a/test/mediaFence.unit.test.ts
+++ b/test/mediaFence.unit.test.ts
@@ -1,0 +1,73 @@
+import { instance, mock, verify, when } from "ts-mockito";
+import { ObsidianUtils } from "../src/obsidian/obsidianUtils";
+import { MediaProcessor } from "../src/obsidian/processors/mediaProcessor";
+
+describe("media references in fenced code", () => {
+    test("leaves media syntax inert in backtick and tilde fences", () => {
+        const mockedUtils = mock(ObsidianUtils);
+        const processor = new MediaProcessor(instance(mockedUtils));
+        const input = `# Markdown examples
+
+\`\`\`markdown
+![Backtick example](figs/backtick.svg)
+\`\`\`
+
+~~~markdown
+![[figs/tilde.png]]
+~~~`;
+
+        expect(processor.process(input)).toBe(input);
+        verify(mockedUtils.findMediaFile("figs/backtick.svg")).never();
+        verify(mockedUtils.findMediaFile("figs/tilde.png")).never();
+    });
+
+    test("treats an unclosed fence as extending to the end", () => {
+        const mockedUtils = mock(ObsidianUtils);
+        const processor = new MediaProcessor(instance(mockedUtils));
+        const input = `# Markdown example
+
+\`\`\`markdown
+![Example](figs/nonexistent.svg)`;
+
+        expect(processor.process(input)).toBe(input);
+        verify(mockedUtils.findMediaFile("figs/nonexistent.svg")).never();
+    });
+
+    test("supports longer fences and CRLF line endings", () => {
+        const mockedUtils = mock(ObsidianUtils);
+        const processor = new MediaProcessor(instance(mockedUtils));
+        const input = [
+            "# Markdown example",
+            "````markdown",
+            "![Example](figs/nonexistent.svg)",
+            "`````",
+        ].join("\r\n");
+
+        expect(processor.process(input)).toBe(input);
+        verify(mockedUtils.findMediaFile("figs/nonexistent.svg")).never();
+    });
+
+    test("still resolves and collects media outside fences", () => {
+        const mockedUtils = mock(ObsidianUtils);
+        when(mockedUtils.shouldCollect()).thenReturn(true);
+        when(mockedUtils.findMediaFile("figs/real.svg")).thenReturn(
+            "/vault/figs/real.svg",
+        );
+        const processor = new MediaProcessor(instance(mockedUtils));
+        const input = `[Real figure](figs/real.svg)
+
+\`\`\`markdown
+![Example](figs/nonexistent.svg)
+\`\`\``;
+
+        const result = processor.process(input);
+
+        expect(result).toContain("[Real figure](/vault/figs/real.svg)");
+        expect(result).toContain(
+            "```markdown\n![Example](figs/nonexistent.svg)\n```",
+        );
+        verify(mockedUtils.findMediaFile("figs/real.svg")).once();
+        verify(mockedUtils.addMedia("/vault/figs/real.svg")).once();
+        verify(mockedUtils.findMediaFile("figs/nonexistent.svg")).never();
+    });
+});


### PR DESCRIPTION
Fixes #397.

Summary

* Apply media transformations only outside fenced code blocks.
* Prevent illustrative media paths inside code examples from being resolved or collected as export dependencies.
* Strengthen the existing skipCodeBlocks() utility to support backtick and tilde fences, longer closing fences, CRLF input, and unclosed fences.
* Preserve normal media resolution and collection outside fenced blocks.

This prevents HTML export from failing with ENOENT when a fenced Markdown example contains a fictitious image path.

Validation

* Added regression tests confirming that Markdown and wikilink media syntax remains inert inside backtick and tilde fences.
* Covered longer fences, CRLF line endings, and unclosed fences.
* Verified that real media outside fences is still resolved and collected normally.
* pnpm fix
* pnpm lint
* pnpm test: 126 tests passed
* pnpm build
* Manually tested with Slides Extended 2.4.2: fenced media syntax renders verbatim in the Obsidian preview and exported HTML opened successfully in a web browser.